### PR TITLE
App name as a parameter.

### DIFF
--- a/src/nwjs-autoupdater/main.go
+++ b/src/nwjs-autoupdater/main.go
@@ -11,13 +11,12 @@ import (
 )
 
 func main() {
-	var bundle, instDir string
+	var bundle, instDir, appName string
 
 	flag.StringVar(&bundle, "bundle", "", "Path to the update package")
 	flag.StringVar(&instDir, "inst-dir", "", "Path to the application install dir")
+	flag.StringVar(&appName, "app-name", "", "Application executable name")
 	flag.Parse()
-
-	appName := "my_app"
 
 	cwd, _ := os.Getwd()
 	logfile, err := os.Create(filepath.Join(cwd, "updater.log"))

--- a/src/nwjs-autoupdater/main.go
+++ b/src/nwjs-autoupdater/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	flag.StringVar(&bundle, "bundle", "", "Path to the update package")
 	flag.StringVar(&instDir, "inst-dir", "", "Path to the application install dir")
-	flag.StringVar(&appName, "app-name", "", "Application executable name")
+	flag.StringVar(&appName, "app-name", "my_app", "Application executable name")
 	flag.Parse()
 
 	cwd, _ := os.Getwd()


### PR DESCRIPTION
Hi! 

First I want to thank you for this updater to apps build with nw.js.

But I think the application executable name should be passed as a parameter. In my company cenario we have a ton of apps running with nw.js and the app exec name can chance for each application, so I need this to be variable (not "my_app").

Best regards,
Rogério Fernandes
