### PR TITLE
Use custom zip extraction method

### DIFF
--- a/src/nwjs-autoupdater/glide.lock
+++ b/src/nwjs-autoupdater/glide.lock
@@ -1,19 +1,8 @@
-hash: 0c7b94ae5b22c2fc22b68a8dc5ef928fd23f67b38ecf89c6cf2a14a924d46c80
-updated: 2016-10-24T19:18:48.011195841+03:00
+hash: 089db5d58dcce28444163bee5aa2289bca80bae995ed56bbef7333582cd58fb9
+updated: 2017-06-14T18:40:00.127652081+03:00
 imports:
-- name: github.com/dsnet/compress
-  version: b9aab3c6a04eef14c56384b4ad065e7b73438862
-  subpackages:
-  - bzip2
-  - bzip2/internal/sais
-  - internal
-  - internal/prefix
 - name: github.com/ivaxer/go-xattr
-  version: 1a541654d8e447148cf23d472c948f9f0078ac50
-- name: github.com/mholt/archiver
-  version: 4a8a092653655d29c8e091cf2ecf91cbe697f0de
-- name: github.com/nwaples/rardecode
-  version: f94841372ddc36be531a5c3e1206238e32e93d74
+  version: d205d0a1b9316c5abcfc61b261d5312301b33e4d
 - name: github.com/skratchdot/open-golang
   version: 75fb7ed4208cf72d323d7d02fd1a5964a7a9073c
   subpackages:

--- a/src/nwjs-autoupdater/glide.yaml
+++ b/src/nwjs-autoupdater/glide.yaml
@@ -1,7 +1,7 @@
 package: nwjs-autoupdater
 import:
 - package: github.com/ivaxer/go-xattr
-- package: github.com/mholt/archiver
+  version: ^1.1.1
 - package: github.com/skratchdot/open-golang
   subpackages:
   - open

--- a/src/nwjs-autoupdater/unzip/main.go
+++ b/src/nwjs-autoupdater/unzip/main.go
@@ -1,0 +1,82 @@
+package unzip
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Unzip a file to a destination and preserve the symlinks
+// Based on http://stackoverflow.com/a/24792688/842097 with symlink additions
+func Unzip(src, dest string) error {
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	os.MkdirAll(dest, 0755)
+
+	// Closure to address file descriptors issue with all the deferred .Close() methods
+	extractAndWriteFile := func(f *zip.File) error {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := rc.Close(); err != nil {
+				panic(err)
+			}
+		}()
+
+		path := filepath.Join(dest, f.Name)
+
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(path, f.Mode())
+		} else if f.FileInfo().Mode()&os.ModeSymlink != 0 {
+			buffer := make([]byte, f.FileInfo().Size())
+			size, err := rc.Read(buffer)
+			if err != nil {
+				return err
+			}
+
+			target := string(buffer[:size])
+
+			err = os.Symlink(target, path)
+			if err != nil {
+				return err
+			}
+		} else {
+			os.MkdirAll(filepath.Dir(path), f.Mode())
+			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err = f.Close(); err != nil {
+					panic(err)
+				}
+			}()
+
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, f := range r.File {
+		err := extractAndWriteFile(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/nwjs-autoupdater/updater/updater_darwin.go
+++ b/src/nwjs-autoupdater/updater/updater_darwin.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"nwjs-autoupdater/unzip"
 
-	"github.com/mholt/archiver"
 	"github.com/ivaxer/go-xattr"
 )
 
@@ -21,7 +21,7 @@ func Update(bundle, instDir, appName string) (error, string) {
 	}
 	defer os.RemoveAll(tempDir)
 
-  err = archiver.Zip.Open(bundle, tempDir)
+  err = unzip.Unzip(bundle, tempDir)
 	if err != nil {
 		return err, appExec
 	}

--- a/src/nwjs-autoupdater/updater/updater_windows.go
+++ b/src/nwjs-autoupdater/updater/updater_windows.go
@@ -3,14 +3,14 @@ package updater
 import (
 	"path/filepath"
 
-	"github.com/mholt/archiver"
+	"nwjs-autoupdater/unzip"
 )
 
 func Update(bundle, instDir, appName string) (error, string) {
 	appExecName := appName + ".exe"
   appExec := filepath.Join(instDir, appExecName)
 
-  err := archiver.Zip.Open(bundle, instDir)
+  err := unzip.Unzip(bundle, instDir)
 	if err != nil {
 		return err, appExec
 	}


### PR DESCRIPTION
mholt/archiver package can't currently handle symbolic links

This adds custom zip extraction based on
https://github.com/mholt/archiver/issues/21#issuecomment-303991010

Closes #8