### PR TITLE
Fix for Issue#6 

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -7,10 +7,16 @@ const {execPath, platform} = process;
 const semver = nw.require('semver');
 const shell = nw.require('shelljs');
 
+// Filename of Application (exe to run after updation)
+const AppExecName='ApplicationName';
+// Filename for Updater
+const AppUpdaterName='updater';
+
+// temp directory details
 const SYSTEM_TEMP_DIR = tmpdir();
 const UPDATER_TEMP_DIR = resolve(SYSTEM_TEMP_DIR, 'my-app-updater');
 const UPDATES_DIR = resolve(UPDATER_TEMP_DIR, 'updates');
-const UPDATER_BIN = resolve(UPDATER_TEMP_DIR, /^win/.test(platform) ? 'updater.exe' : 'updater');
+const UPDATER_BIN = resolve(UPDATER_TEMP_DIR, /^win/.test(platform) ? AppUpdaterName + '.exe' : AppUpdaterName);
 
 shell.mkdir('-p', UPDATES_DIR);
 
@@ -21,6 +27,17 @@ const {
   appInstDir,
   bundledUpdaterPath,
 } = resolvePaths(execPath, platform);
+
+/*  TO RUN AS BACKGROUND APPLICATION
+
+run('src/view/index.html', appManifest.window)
+  .then(() => {
+    const win = nw.Window.get();
+    win.hide()
+})
+
+*/
+
 
 run('index.html', appManifest.window)
   .then(() => {
@@ -58,12 +75,12 @@ function resolvePaths (execPath, platform) {
   } else if (platform === 'win32') {
     appDir = dirname(execPath);
     appInstDir = appDir;
-    appExec = resolve(appDir, 'MyApp.exe');
+    appExec = resolve(appDir, AppExecName + '.exe');
     bundledUpdaterPath = resolve(appDir, 'updater.exe');
   } else {
     appDir = dirname(execPath);
     appInstDir = appDir;
-    appExec = resolve(appDir, 'MyApp');
+    appExec = resolve(appDir, AppExecName);
     bundledUpdaterPath = resolve(appDir, 'updater');
   }
 
@@ -84,6 +101,7 @@ function startUpdate (bundlePath) {
   shell.chmod(755 & ~process.umask(), UPDATER_BIN);
 
   spawn(UPDATER_BIN, [
+    '--app-name', AppExecName,
     '--bundle', bundlePath,
     '--inst-dir', appInstDir,
   ], {

--- a/src/nwjs-autoupdater/main.go
+++ b/src/nwjs-autoupdater/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-
+	"time"
 	"github.com/skratchdot/open-golang/open"
 	"nwjs-autoupdater/updater"
 )
@@ -24,6 +24,8 @@ func main() {
 		panic(err)
 	}
 	defer logfile.Close()
+
+	time.Sleep(2 * time.Second)
 
 	logger := log.New(logfile, "", log.LstdFlags)
 


### PR DESCRIPTION
https://github.com/oaleynik/nwjs-autoupdater/issues/6#issue-218345777

- The above issue is because the application.exe does not exit as soon as the updater.exe is spawned. Add a sleep of 1 or 2 seconds to solve this issue.

- Pass application filename to updater while spawning, in example file.

- Made example more readable.